### PR TITLE
Add LineBuffer function

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -185,3 +185,8 @@ func ProcessCompletion(textC *C.char, lineC *C.char, start, end int) **C.char {
 
 	return (**C.char)(ptr)
 }
+
+// LineBuffer returns the line gathered so far.
+func LineBuffer() string {
+	return C.GoString(C.rl_line_buffer)
+}


### PR DESCRIPTION
Add LineBuffer function that enables you to know what the user is editing.
This function is based on [rl_line_buffer](http://www.delorie.com/gnu/docs/readline/rlman_28.html).
It is useful when you want to know whether the user is writing something or not from other goroutine.
