### PR TITLE
readline version bump

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -8,8 +8,8 @@
 package readline
 
 /*
-#cgo darwin CFLAGS: -I/usr/local/Cellar/readline/6.2.4/include/
-#cgo darwin LDFLAGS: -L/usr/local/Cellar/readline/6.2.4/lib/
+#cgo darwin CFLAGS: -I/usr/local/Cellar/readline/6.3.8/include/
+#cgo darwin LDFLAGS: -L/usr/local/Cellar/readline/6.3.8/lib/
 #cgo LDFLAGS: -lreadline
 
 #include <stdio.h>


### PR DESCRIPTION
This bumps the readline version on OS X. The best way would be to determine this dynamically (`pkg-config` didn’t work for me), but I needed a quick way to get this working.