### PR TITLE
Fix CFLAGS and LDFLAGS

### DIFF
--- a/readline.go
+++ b/readline.go
@@ -8,8 +8,8 @@
 package readline
 
 /*
-#cgo darwin CFLAGS: -I/usr/local/Cellar/readline/6.3.8/include/
-#cgo darwin LDFLAGS: -L/usr/local/Cellar/readline/6.3.8/lib/
+#cgo darwin CFLAGS: -I/usr/local/opt/readline/include
+#cgo darwin LDFLAGS: -L/usr/local/opt/readline/lib
 #cgo LDFLAGS: -lreadline
 
 #include <stdio.h>


### PR DESCRIPTION
Couldn't compile because I had a newer version of readline.

Homebrew automatically links to the current version:

```
$ brew info readline
readline: stable 7.0.5 (bottled), devel 8.0-alpha [keg-only]
Library for command-line editing
https://tiswww.case.edu/php/chet/readline/rltop.html
/usr/local/Cellar/readline/7.0.1 (46 files, 2MB)
  Poured from bottle on 2016-12-17 at 23:02:11
/usr/local/Cellar/readline/7.0.3_1 (46 files, 1.5MB)
  Poured from bottle on 2017-11-01 at 21:37:50
/usr/local/Cellar/readline/7.0.5 (46 files, 1.5MB)
  Poured from bottle on 2018-07-15 at 23:24:31
From: https://github.com/Homebrew/homebrew-core/blob/master/Formula/readline.rb
==> Options
--devel
	Install development version 8.0-alpha
==> Caveats
This formula is keg-only, which means it was not symlinked into /usr/local,
because macOS provides the BSD libedit library, which shadows libreadline.
In order to prevent conflicts when programs look for libreadline we are
defaulting this GNU Readline installation to keg-only.

For compilers to find this software you may need to set:
    LDFLAGS:  -L/usr/local/opt/readline/lib
    CPPFLAGS: -I/usr/local/opt/readline/include
```